### PR TITLE
Fix a bug when parsing chunked data

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -90,6 +90,7 @@ class ChunkParser(object):
     def process(self, data):
         if self.state == CHUNK_PARSER_STATE_WAITING_FOR_SIZE:
             line, data = HttpParser.split(data)
+            if line == False: return line, data
             self.size = int(line, 16)
             self.state = CHUNK_PARSER_STATE_WAITING_FOR_DATA
         elif self.state == CHUNK_PARSER_STATE_WAITING_FOR_DATA:


### PR DESCRIPTION
if the data ends with the size without CRLF, this patch can prevent the parser from raising an error.
test program:

    from proxy import *
    cp = ChunkParser()
    data1 = b'3\r\nabc\r\n4'
    data2 = b'\r\nabcd\r\n'
    cp.parse(data1)			# error
    # would be correct if do `cp.parse(data1 + data2)`